### PR TITLE
Minor typo fix in MIX

### DIFF
--- a/inbox/mix.xml
+++ b/inbox/mix.xml
@@ -219,7 +219,7 @@
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
     <subscribe node='urn:xmpp:mix:nodes:subject'/>
     <subscribe node='urn:xmpp:mix:nodes:config'/>
-  </pubsub>
+  </join>
 </iq>
 ]]></example>
       <p>The conversation must process the join atomically. The conversation responds with an IQ-result. This stanza includes the nodes to which the user was subscribed, as well as the permanent participant identifier (PID) of the user.</p>
@@ -234,7 +234,7 @@
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
     <subscribe node='urn:xmpp:mix:nodes:subject'/>
     <subscribe node='urn:xmpp:mix:nodes:config'/>
-  </pubsub>
+  </join>
 </iq>
       ]]></example>
       <p>As noted, the participant might not be subscribed to all nodes (in this case only messages, participants, and subject).</p>
@@ -247,7 +247,7 @@
     <subscribe node='urn:xmpp:mix:nodes:messages'/>
     <subscribe node='urn:xmpp:mix:nodes:participants'/>
     <subscribe node='urn:xmpp:mix:nodes:subject'/>
-  </pubsub>
+  </join>
 </iq>
       ]]></example>
       <p>The conversation also adds the user to the participants node and sends a notification.</p>

--- a/inbox/mix.xml
+++ b/inbox/mix.xml
@@ -74,7 +74,7 @@
   <ul>
     <li>MIX conversations (roughly equivalent to MUC rooms) are hosted on a MIX domain, e.g. `mix.example.com`, which is discoverable through &xep0030;. Each conversation on the service may then be discovered and queried.</li>
     <li>Re-using the model from &xep0163; (where every user JID (e.g., `user@example.com`) is its own pubsub service), in MIX each conversation (e.g., `conversation@mix.example.com`) is a pubsub service.</li>
-    <li>A conversation's pubsub service can contains any number of nodes for different event types or data formats. As described below, this document defines several standard nodes; however, future specifications or proprietary services can define their own nodes for extensibility.</li>
+    <li>A conversation's pubsub service can contain any number of nodes for different event types or data formats. As described below, this document defines several standard nodes; however, future specifications or proprietary services can define their own nodes for extensibility.</li>
     <li>All information sharing within the conversation uses standard PubSub semantics from &xep0060;. There are no special-purpose message or presence stanzas, such as those used to join roooms in MUC.</li>
     <li>Affiliations with the nodes are, by default, tied together as affiliations on the conversation itself rather than individual nodes, so that allowing or denying access to a conversation is a single affiliation change.</li>
     <li>&xep0313; (MAM) is used for all history access, with each node being individually addressable for MAM queries. This simplifies implementation compared to MUC (which had a specialized and rather limited history retrieval mechanism).</li>

--- a/inbox/mix.xml
+++ b/inbox/mix.xml
@@ -496,7 +496,22 @@
   <p>None.</p>
 </section1>
 <section1 topic='XMPP Registrar Considerations' anchor='registrar'>
-  <p>Register a namespace.</p>
+  <p>
+    This specification defines the following XML namespaces:
+  </p>
+  <ul>
+    <li>urn:xmpp:mix:0</li>
+  </ul>
+  <p>
+    The &REGISTRAR; shall include the foregoing namespaces in its disco
+    features registry as defined in &xep0030;.
+  </p>
+    <code><![CDATA[
+<var>
+  <name>urn:xmpp:mix:0</name>
+  <desc>Indicates support for MIX multi-user messaging</desc>
+  <doc>XEP-xxxx</doc>
+</var>]]></code>
 </section1>
 <section1 topic='XML Schema' anchor='schema'>
   <p>TBD.</p>


### PR DESCRIPTION
A few minor typo / example fixes, and an initial registrar considerations section (still todo: Register the pubsub nodes; I figured they might change though so I left them out of this PR).